### PR TITLE
V1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .vscode/
 bwd/
 assets/settings.json
+assets/MargarineData.sqlite

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MargarineBot - Version: Release 1.3.0
+# MargarineBot - Version: Release 1.3.1
 ![License](https://img.shields.io/github/license/Butterstroke/MargarineBot.svg?style=flat-square) ![Support Server](https://discordapp.com/api/guilds/303253034551476225/widget.png)
 
 <b>Dependencies</b>

--- a/assets/settingsExample.json
+++ b/assets/settingsExample.json
@@ -2,7 +2,7 @@
     "token": "Token Key",
     "prefix": "Prefix", 
     "build": {
-        "version": "Release 1.3.0",
+        "version": "Release 1.3.1",
         "releaseDate": "May 19th, 2020"
     },
     "database": "./assets/MargarineData.sqlite"

--- a/assets/settingsExample.json
+++ b/assets/settingsExample.json
@@ -3,7 +3,7 @@
     "prefix": "Prefix", 
     "build": {
         "version": "Release 1.3.1",
-        "releaseDate": "May 19th, 2020"
+        "releaseDate": "June 16th, 2020"
     },
     "database": "./assets/MargarineData.sqlite"
 }

--- a/assets/speech/en-CA/config.js
+++ b/assets/speech/en-CA/config.js
@@ -44,5 +44,25 @@ module.exports = {
     "setprefix": [
         "Okay! I've updated the guild prefix to -editPrefix.",
         "I'll be sure to stay on the lookout for -editPrefix now."
-    ]
+    ],
+    "disablecommand": {
+        "noStr": [
+            "I need a command name to disable something!",
+            "You can't expect me to read your mind! Give me a command name to work with!"
+        ],
+        "guarded": [
+            "This command is guarded. I can't disable it as it will affect my abilities too much.",
+            "No can do. This is a guarded command and I'm not willing to disable those as it will break your experience."
+        ],
+        "disable": [
+            "Okay! I've disabled -name. You are no longer able to use it.",
+            "-name is no longer enabled.",
+            "And... done! You no longer have to worry about -name running in the guild now."
+        ],
+        "enable": [
+            "Okay! I've reenabled -name. You are able to use it.",
+            "-name has been reenabled!",
+            "*Flicks switch* Okay! -name has been reenabled!"
+        ]
+    }
 };

--- a/assets/speech/en-CA/config.js
+++ b/assets/speech/en-CA/config.js
@@ -13,11 +13,13 @@ module.exports = {
             "You're all set! -target is now set to -item!"
         ],
         "list": [
-            "Okay! Here's your starboard settings:\n__Channel:__ <#-channel>\n__Emote:__ -emote\n__Amount:__ -amount"
+            "Okay! Here's your starboard settings:\n__Channel:__ <#-channel>\n__Emote:__ -emote\n__Amount:__ -amount",
+            "Behold! Your starboard settings:\n__Channel:__ <#-channel>\n__Emote:__ -emote\n__Amount:__ -amount"
         ],
         "noItem": [
             "Hmm... looks like you didn't want me to set anything.",
-            "Didn't want me to set anything? Okay then..."
+            "Didn't want me to set anything? Okay then...",
+            "Nothing to set this to? Okay, I guess I won't set anything then."
         ],
         "remove": [
             "Okay! I've set -target back to its original state.",

--- a/assets/speech/en-CA/cooking.js
+++ b/assets/speech/en-CA/cooking.js
@@ -19,19 +19,11 @@ module.exports = {
         "You have caught -kind! You placed it in your inventory.",
         "Oh! A -kind. Looks like that's a winner. You have placed it in your inventory."
     ],
-    "harvest": {
-        "noRow": [
-            "You should redeem your first daily. Then, you can harvest all you like."
-        ],
-        "noCredits": [
-            "Hmm... you seem to be lacking in credits. Find some and come back."
-        ],
-        "success": [
-            "You found a -kind. You placed it in your inventory",
-            "That looks like a fine -kind. You placed it in your inventory.",
-            "A -kind! You could make a good meal out of that one. You placed it in your inventory."
-        ]
-    },
+    "harvest": [
+        "You found a -kind. You placed it in your inventory",
+        "That looks like a fine -kind. You placed it in your inventory.",
+        "A -kind! You could make a good meal out of that one. You placed it in your inventory."
+    ],
     "inventory": [ //No account. Seperate from dataCheck since no credits are needed
         "Doesn't look like you've redeemed your first daily yet. Do that and then you'll have an inventory to look at!",
         "You don't have an inventory yet. Redeem your first daily to get one!"

--- a/assets/speech/en-CA/dataCheck.js
+++ b/assets/speech/en-CA/dataCheck.js
@@ -44,12 +44,19 @@ module.exports = {
     "noItems": [ //When an item does not exist in the items.json file.
         "Hmm... nope. Not finding that item here.",
         "That's not an item.",
-        "Does that... even exist? I can't find that item"
+        "Does that... even exist? I can't find that item",
+        "That's a thing? Huh, must be exotic since I've never heard about that item."
+    ],
+    "noRecipe": [ //When there is no recipes attached to an item in the items.json file.
+        "I couldn't find a recipe like that!",
+        "There's no recipe like that!",
+        "Ditto... the recipe for this doesn't exist." 
     ],
     "noZero": [ //When a command requires a nonzero amount.
         "Hey! You don't have any of this!",
         "You can't have nothing here!",
-        "Zero... you can't have zero be an amount here."
+        "Zero... you can't have zero be an amount here.",
+        "No zeros! I need something other than that!"
     ],
     "revoked": [ //User tried to make a new profile after deleting their data (Less than 24 hours)
         "You can't do this yet! It's been too soon since you've deleted your own data.",

--- a/assets/speech/en-CA/music.js
+++ b/assets/speech/en-CA/music.js
@@ -1,164 +1,159 @@
-exports.join = {
-    "noConnect": [
-        ":x: I do not have enough permissions to connect to your voice channel. I am missing the connect permission. (You may want to check if I can speak in that channel too :wink:)",
-        "Huh, looks like I do not have the permissions to connect to your voice channel. I'm currently missing the connect permission. (You should check if I can also speak in the channel too!)"
-    ],
-    "noSpeak": [
-        "Wow. Invite me to play music for you, yet I can't speak in the channel. You are more heartless than my owner. Give me the channel permission to speak and then try again.",
-        "Yikes. I've been given the silent treatment. I can't speak in your channel! Please give me the permission to speak and then try again!"
-    ],
-    "success": [ //Parameter 1: Voice channel name
-        "Now tuned into: -param1. Ready and awaiting orders!",
-        "Preparing the DJ station in -param1. Now ready for your requested songs!",
-        "-param1 is ready to receive your requested songs! All we need now is some music!"
-    ]
-};
+/* 
+ * Speech for all music commands
+ */
 
-exports.leave = [
-    "I have left -channel.",
-    "The party is now over in -channel.",
-    "Thanks for the fun! I've cleaned up and have left -channel.",
-    "And that's it for the fun in -channel! We should do that again some other time."
-];
-
-exports.nowplaying = {
-    "noQueue": [
-        "I don't have any songs to play, baka! Add some using -prefixqueueadd `Youtube URL`",
-        "The queue is as existant as your waifu right now. You should add some songs."
+module.exports = {
+    "join": {
+        "noConnect": [
+            ":x: I do not have enough permissions to connect to your voice channel. I am missing the connect permission. (You may want to check if I can speak in that channel too :wink:)",
+            "Huh, looks like I do not have the permissions to connect to your voice channel. I'm currently missing the connect permission. (You should check if I can also speak in the channel too!)"
+        ],
+        "noSpeak": [
+            "Wow. Invite me to play music for you, yet I can't speak in the channel. You are more heartless than my owner. Give me the channel permission to speak and then try again.",
+            "Yikes. I've been given the silent treatment. I can't speak in your channel! Please give me the permission to speak and then try again!"
+        ],
+        "success": [ //Parameter 1: Voice channel name
+            "Now tuned into: -param1. Ready and awaiting orders!",
+            "Preparing the DJ station in -param1. Now ready for your requested songs!",
+            "-param1 is ready to receive your requested songs! All we need now is some music!"
+        ]
+    },
+    "leave": [
+        "I have left -channel.",
+        "The party is now over in -channel.",
+        "Thanks for the fun! I've cleaned up and have left -channel.",
+        "And that's it for the fun in -channel! We should do that again some other time."
     ],
-    "notPlay": [
-        "Hmm... good question. None of the above. I am not playing anything right now!",
-        "There isn't any music playing right now.",
-        "But... it's silent. Nothing is playing!"
-    ]
-};
-
-exports.pause = { 
-    "paused": [
-        "BAKA! Your stream is already paused!",
-        "The stream is already paused, baka!"
+    "nowplaying": {
+        "noQueue": [
+            "I don't have any songs to play, baka! Add some using -prefixqueueadd `Youtube URL`",
+            "The queue is as existant as your waifu right now. You should add some songs."
+        ],
+        "notPlay": [
+            "Hmm... good question. None of the above. I am not playing anything right now!",
+            "There isn't any music playing right now.",
+            "But... it's silent. Nothing is playing!"
+        ]
+    },
+    "pause": {
+        "paused": [
+            "BAKA! Your stream is already paused!",
+            "The stream is already paused, baka!"
+        ],
+        "success": [
+            "⏸ The mix is now paused.",
+            "Poof! Just like that, your tunes are paused! ⏸"
+        ]
+    },
+    "play": {
+        "alreadyPlay": [
+            "I'm already playing in your channel, baka!",
+            "Can't you tell I'm playing music for you..."
+        ], //Already playing
+        "noQueue": [
+            "Add some songs to the mix first with -prefixqueueadd [Youtube URL]",
+            "Whoops! You forgot to add some songs to the queue!",
+            "BAKA! There is no music in your queue!"
+        ], //Nothing to play
+        "allDone": [
+            "Looks like my job is done. Add more songs or kick me out of the channel. It doesn't matter to me, baka.",
+            "Job's done! Time to add more songs or kick me out."
+        ], //No more to play
+        "nextSong": [ //Parameter 1: Requester, Parameter 2: Song title
+            "📻 Playing -param1's request: **-param2**",
+            "📻 Now listening to **-param2**, requested by -param1!"
+        ] //Next song playing
+    },
+    "queue": {
+        "noList": [
+            "You don't have anything in your queue at the moment. Add some with the queueadd command.",
+            "There's nothing here. You should add some songs with queueadd!"
+        ],
+        "highCount": [
+            "I can't show you that page for its page number is greater than my queue pages. There are currently -pgs",
+            "Your number is higher than -pgs. So, there is nothing to see there."
+        ]
+    },
+    "queueadd": {
+        "noURL": [
+            "You must provide me with a valid Youtube URL, BAKA!",
+            "What is this? This is not a URL I requested!",
+            "Wha- This isn't a Youtube URL! BAKA!"
+        ],
+        "listDetect": [
+            "Looks like you want a playlist. Hold tight, this may take awhile."
+        ],
+        "errCatch": [ //Parameter 1: Youtube ID
+            "Whoops! Looks like I can't access this video. <https://youtu.be/-param1>"
+        ],
+        "success": [ //Parameter 1: Song title
+            "🎵 Added **-param1** to the queue 🎶",
+            "🎧 **-param1** has been added to the queue"
+        ],
+        "multi": [ //Parameter 1: Number of songs
+            "🎵 Added **-param1** songs to the queue 🎶",
+            "I've finished adding **-param1** songs to the queue. Time for a break."
+        ]
+    },
+    "remove": [
+        "**-song** has been removed from the queue.",
+        "Okay! **-song** has been removed from the queue."
     ],
-    "success": [
-        "⏸ The mix is now paused.",
-        "Poof! Just like that, your tunes are paused! ⏸"
-    ]
-};
-
-exports.play = {
-    "alreadyPlay": [
-        "I'm already playing in your channel, baka!",
-        "Can't you tell I'm playing music for you..."
-    ], //Already playing
-    "noQueue": [
-        "Add some songs to the mix first with -prefixqueueadd [Youtube URL]",
-        "Whoops! You forgot to add some songs to the queue!",
-        "BAKA! There is no music in your queue!"
-    ], //Nothing to play
-    "allDone": [
-        "Looks like my job is done. Add more songs or kick me out of the channel. It doesn't matter to me, baka.",
-        "Job's done! Time to add more songs or kick me out."
-    ], //No more to play
-    "nextSong": [ //Parameter 1: Requester, Parameter 2: Song title
-        "📻 Playing -param1's request: **-param2**",
-        "📻 Now listening to **-param2**, requested by -param1!"
-    ] //Next song playing
-};
-
-exports.queue = {
-    "noList": [
-        "You don't have anything in your queue at the moment. Add some with the queueadd command.",
-        "There's nothing here. You should add some songs with queueadd!"
+    "resume": {
+        "noPause": [
+            "The stream isn't paused at the moment.",
+            "Huh? I'm playing music right now."
+        ],
+        "success": [
+            "▶ Now resuming your tunes. Keep partying!",
+            "Time to start partying again! I've resumed your tunes."
+        ]
+    },
+    "skip": [
+        "⏭ Skipped the current song.",
+        "On to the next song! ⏭",
+        "⏭ Okay! Playing the next song then!"
     ],
-    "highCount": [
-        "I can't show you that page for its page number is greater than my queue pages. There are currently -pgs",
-        "Your number is higher than -pgs. So, there is nothing to see there."
-    ]
-};
-
-exports.queueadd = {
-    "noURL": [
-        "You must provide me with a valid Youtube URL, BAKA!",
-        "What is this? This is not a URL I requested!",
-        "Wha- This isn't a Youtube URL! BAKA!"
-    ],
-    "listDetect": [
-        "Looks like you want a playlist. Hold tight, this may take awhile."
-    ],
-    "errCatch": [ //Parameter 1: Youtube ID
-        "Whoops! Looks like I can't access this video. <https://youtu.be/-param1>"
-    ],
-    "success": [ //Parameter 1: Song title
-        "🎵 Added **-param1** to the queue 🎶",
-        "🎧 **-param1** has been added to the queue"
-    ],
-    "multi": [ //Parameter 1: Number of songs
-        "🎵 Added **-param1** songs to the queue 🎶",
-        "I've finished adding **-param1** songs to the queue. Time for a break."
-    ]
-};
-
-exports.remove = [
-    "**-song** has been removed from the queue.",
-    "Okay! **-song** has been removed from the queue."
-];
-
-exports.resume = {
-    "noPause": [
-        "The stream isn't paused at the moment.",
-        "Huh? I'm playing music right now."
-    ],
-    "success": [
-        "▶ Now resuming your tunes. Keep partying!",
-        "Time to start partying again! I've resumed your tunes."
-    ]
-};
-
-exports.skip = [
-    "⏭ Skipped the current song.",
-    "On to the next song! ⏭",
-    "⏭ Okay! Playing the next song then!"
-];
-
-exports.volume = {
-    "noArgs": [
-        "📢 Volume: -vol%",
-        "Currently playing at -vol%"
-    ],
-    "zero": [
-        "You might as well mute me if you don't want any noise."
-    ],
-    "overHun": [
-        "100% is the max. You just can't have 110%.."
-    ],
-    "notPlay": [
-        "Kind of hard to adjust the volume if I am not playing music."
-    ],
-    "success": [ //Parameter 1: Action, Parameter 2: volume
-        "-param1 the volume! Volume: -param2%",
-        "-param1 the volume to -param2% as requested!"
-    ]
-};
-
-exports.general = {
-    "userVC": [
-        "You need to be in a voice channel first, BAKA!",
-        "You aren't even in a voice channel! Don't leave me all alone in a voice channel!",
-        "BAKA! You aren't even in a voice channel to begin with! Enter in my voice channel and tell me face to face!"
-    ], //User not in VC
-    "noQueue": [
-        "I'm not even in a voice channel, baka!",
-        "I need to be playing music before we do any of that!",
-        "It looks like I'm not in a voice channel to begin with...",
-        "How can I be playing music when I am not in a voice channel, baka!"
-    ], //Margarine not in a VC
-    "mismatch": [
-        "You are not connected in my voice channel, baka!",
-        "BAKA! You aren't even in my voice channel to begin with!",
-        "You are not in my voice channel! Come in and tell me face to face!",
-        "I'm already playing in another VC. You should join in on the fun instead!"
-    ], //Margarine not in the same VC
-    "noHandler": [ //Margarine needs a dispatcher active in order to do the command
-        "Hey! I'm not playing anything right now!",
-        "You should really play some music before you try to interact with the music."
-    ]
+    "volume": {
+        "noArgs": [
+            "📢 Volume: -vol%",
+            "Currently playing at -vol%"
+        ],
+        "zero": [
+            "You might as well mute me if you don't want any noise."
+        ],
+        "overHun": [
+            "100% is the max. You just can't have 110%.."
+        ],
+        "notPlay": [
+            "Kind of hard to adjust the volume if I am not playing music."
+        ],
+        "success": [ //Parameter 1: Action, Parameter 2: volume
+            "-param1 the volume! Volume: -param2%",
+            "-param1 the volume to -param2% as requested!"
+        ]
+    },
+    "general": {
+        "userVC": [
+            "You need to be in a voice channel first, BAKA!",
+            "You aren't even in a voice channel! Don't leave me all alone in a voice channel!",
+            "BAKA! You aren't even in a voice channel to begin with! Enter in my voice channel and tell me face to face!"
+        ], //User not in VC
+        "noQueue": [
+            "I'm not even in a voice channel, baka!",
+            "I need to be playing music before we do any of that!",
+            "It looks like I'm not in a voice channel to begin with...",
+            "How can I be playing music when I am not in a voice channel, baka!"
+        ], //Margarine not in a VC
+        "mismatch": [
+            "You are not connected in my voice channel, baka!",
+            "BAKA! You aren't even in my voice channel to begin with!",
+            "You are not in my voice channel! Come in and tell me face to face!",
+            "I'm already playing in another VC. You should join in on the fun instead!"
+        ], //Margarine not in the same VC
+        "noHandler": [ //Margarine needs a dispatcher active in order to do the command
+            "Hey! I'm not playing anything right now!",
+            "You should really play some music before you try to interact with the music."
+        ]
+    }
 };

--- a/assets/speech/en-CA/system.js
+++ b/assets/speech/en-CA/system.js
@@ -82,7 +82,9 @@ module.exports = {
     "inhibitor": {
         "cooldown": [
             "Hold up! You can't use this yet! Try again in -remaining.",
-            "You have just used this command. You can use this command again in -remaining."
+            "You have just used this command. You can use this command again in -remaining.",
+            "You'll have to wait! This command's cooldown still has -remaining left.",
+            "Not yet! You'll have to wait for another -remaining before trying again."
         ],
         "guildDisable": [
             "Whoops! Looks like this command is disabled here!",

--- a/commands/Config/disableCommand.js
+++ b/commands/Config/disableCommand.js
@@ -1,0 +1,35 @@
+const { Command } = require("klasa");
+
+module.exports = class extends Command {
+    constructor(...args) {
+        super(...args, {
+            name: "disablecommand",
+            enabled: true,
+            guarded: true,
+            runIn: ["text"],
+            aliases: ["disablecmd", "dcmd"],
+            description: "Disable or reenable a command for your guild.",
+            usage: "[command:command]",
+            permissionLevel: 6
+        });
+
+        this.humanUse = "<command>";
+    }
+
+    async run(msg, [cmd]) {
+        if (!cmd) { return msg.sendLocale("DCOMMAND_NOSTR", [msg]); }
+        if (cmd.guarded) { return msg.sendLocale("DCOMMAND_GUARDED", [msg]); }
+
+        var disabled = msg.guild.settings.disabledCommands.includes(cmd.name);
+
+        if (!disabled) {
+            msg.guild.settings.update("disabledCommands", cmd, { action: "add" }).then(() => {
+                msg.sendLocale("DCOMMAND_DISABLE", [msg, cmd.name]);
+            });
+        } else {
+            msg.guild.settings.update("disabledCommands", cmd, { action: "remove" }).then(() => {
+                msg.sendLocale("DCOMMAND_ENABLE", [msg, cmd.name]);
+            });
+        }
+    }
+};

--- a/commands/Economy/Cooking/craft.js
+++ b/commands/Economy/Cooking/craft.js
@@ -10,15 +10,15 @@ module.exports = class extends Command {
             aliases: ["cook"],
             cooldown: 30,
             description: "Make items",
-            usage: "[item:str] [amount:str]", usageDelim: " "
+            usage: "<item:str> [amount:intCheck{1,}]", usageDelim: " "
         });
     }
 
     async run(msg, [item=item.toLowerCase(), amount=1]) {
         const itemDB = this.client.itemData;
         let tarItem = itemDB[item];
-        if (!tarItem) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "noItems"])); }
-        if (!tarItem.recipe) { return msg.channel.send(this.client.speech(msg, ["craft", "noRecipe"])); }
+        if (!tarItem) { return msg.sendLocale("DATACHECK_NOITEMS"); }
+        if (!tarItem.recipe) { return msg.sendLocale("DATACHECK_NORECIPE"); }
 
         if (amount === "help") {
             var recipeList = [];
@@ -36,7 +36,7 @@ module.exports = class extends Command {
         }
 
         var prodData = this.client.dataManager("select", msg.author.id, "product");
-        if (!prodData) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "noAccount"])); }
+        if (!prodData) { return msg.sendLocale("DATACHECK_NOACCOUNT"); }
         
         var fishData = this.client.dataManager("select", msg.author.id, "fishing");
         var harvData = this.client.dataManager("select", msg.author.id, "harvest");
@@ -61,6 +61,6 @@ module.exports = class extends Command {
         }
 
         this.client.dataManager("update", [`${tarItem.name}=${(prodData[tarItem.name] + amount)}`, msg.author.id], "product");
-        msg.channel.send(this.client.speech(msg, ["craft", "success"], [["-amount", amount], ["-item", tarItem.emote]]));
+        msg.sendLocale("CRAFT", [msg, amount, tarItem.emote]);
     }
 };

--- a/commands/Economy/Cooking/fish.js
+++ b/commands/Economy/Cooking/fish.js
@@ -13,11 +13,9 @@ module.exports = class extends Command {
     }
 
     async run(msg) {
-        const items = this.client.itemData;
-
         var data = this.client.dataManager("select", msg.author.id, "users");
-        if (!data) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "noAccount"])); }
-        if (data.credits < 10) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "lackCredits"])); }
+        if (!data) { return msg.sendLocale("DATACHECK_NOACCOUNT"); }
+        if (data.credits < 10) { return msg.sendLocale("DATACHECK_LACKCREDIT"); }
 
         const fishType = ["trash", "fish", "crab", "squid", "shark"];
 
@@ -36,6 +34,6 @@ module.exports = class extends Command {
         this.client.dataManager("update", [`${kind}=${(fishData[kind] + 1)}`, msg.author.id], "fishing");
         this.client.dataManager("update", [`credits=${(data.credits - 10)}`, msg.author.id], "users");
 
-        msg.channel.send(this.client.speech(msg, ["fish"], [["-kind", items[kind].emote]]));
+        msg.sendLocale("FISH", [msg, this.client.itemData[kind].emote]);
     }
 };

--- a/commands/Economy/Cooking/harvest.js
+++ b/commands/Economy/Cooking/harvest.js
@@ -13,11 +13,9 @@ module.exports = class extends Command {
     }
 
     async run(msg) {
-        const items = this.client.itemData;
-
         var data = this.client.dataManager("select", msg.author.id, "users");
-        if (!data) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "noAccount"])); }
-        if (data.credits < 10) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "lackCredits"])); }
+        if (!data) { return msg.sendLocale("DATACHECK_NOACCOUNT"); }
+        if (data.credits < 10) { return msg.sendLocale("DATACHECK_LACKCREDIT"); }
 
         const harvType = ["greenapple", "apple", "lemon", "potato", "bread", "rice", "egg", "chocolate"];
 
@@ -39,6 +37,6 @@ module.exports = class extends Command {
         this.client.dataManager("update", [`${item}=${(harvData[item] + 1)}`, msg.author.id], "harvest");
         this.client.dataManager("update", [`credits=${(data.credits - 10)}`, msg.author.id], "users");
 
-        msg.channel.send(this.client.speech(msg, ["harvest"], [["-kind", items[item].emote]]));
+        msg.sendLocale("HARVEST", [msg, this.client.itemData[item].emote]);
     }
 };

--- a/commands/Economy/Cooking/sell.js
+++ b/commands/Economy/Cooking/sell.js
@@ -13,14 +13,14 @@ module.exports = class extends Command {
 
     async run(msg, [item=item.toLowerCase(), amount]) {
         const itemDB = this.client.itemData[item];
-        if (!itemDB) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "noItems"])); }
+        if (!itemDB) { return msg.sendLocale("DATACHECK_NOITEMS"); }
 
         var data = this.client.dataManager("select", msg.author.id, "users");
-        if (!data) { return this.client.speech(msg, ["func-dataCheck", "noAccount"]); }
+        if (!data) { return msg.sendLocale("DATACHECK_NOACCOUNT"); }
 
         var itemData = this.client.dataManager("select", msg.author.id, itemDB.category);
         if (!amount) { amount = itemData[item]; }
-        if (amount === 0 || !amount) { return msg.channel.send(this.client.speech(msg, ["func-dataCheck", "noZero"])); }
+        if (amount === 0 || !amount) { return msg.sendLocale("DATACHECK_NOZERO"); }
         if (itemData[item] < amount) { return msg.channel.send(this.client.speech(msg, ["sell", "notEnough"])); }
 
         this.client.dataManager("update", [`credits=${(data.credits + (itemDB.sell * amount))}`, msg.author.id], "users");

--- a/commands/Economy/Cooking/sell.js
+++ b/commands/Economy/Cooking/sell.js
@@ -26,6 +26,6 @@ module.exports = class extends Command {
         this.client.dataManager("update", [`credits=${(data.credits + (itemDB.sell * amount))}`, msg.author.id], "users");
         this.client.dataManager("update", [`${item}=${(itemData[item] - amount)}`, msg.author.id], itemDB.category);
 
-        msg.channel.send(this.client.speech(msg, ["sell", "success"], [["-item", itemDB.emote], ["-amount", amount], ["-price", (itemDB.sell * amount)]]));        
+        msg.sendLocale("SELL", [msg, itemDB.emote, amount, (itemDB.sell * amount)]);       
     }
 };

--- a/commands/Economy/revoke.js
+++ b/commands/Economy/revoke.js
@@ -5,6 +5,7 @@ module.exports = class extends Command {
         super(...args, {
             name: "revoke",
             enabled: true,
+            guarded: true,
             runIn: ["text"],
             description: "Delete your user data in Margarine's systems.",
             extendedHelp: "By deleting your data, you will not be able to create another profile for another 24 hours since deletion. The data is not recoverable."

--- a/commands/Fun/Polling/createPoll.js
+++ b/commands/Fun/Polling/createPoll.js
@@ -1,0 +1,33 @@
+const { Command } = require("klasa");
+
+module.exports = class extends Command {
+    constructor(...args) {
+        super(...args, {
+            name: "createpoll",
+            runIn: ["text"],
+            description: "Create a new poll for the guild to vote on!",
+            usage: "[title:str] [description:str] [options:str][...]", usageDelim: ",",
+        });
+
+        this.humanUse = "[title]_[description]_[...options]";
+    }
+
+    async run(msg, [title, desc, ...option]) {
+        if (!title) { return msg.sendLocale("POLL_NOTITLE", [msg]); }
+        if (!desc) { return msg.sendLocale("POLL_NODESC", [msg]); }
+        if (option.length < 2) { return msg.sendLocale("POLL_NOOPTION", [msg]); }
+
+        if (msg.guild.settings.poll.info) { return msg.sendLocale("POLL_NOCREATE", [msg]); }
+
+        var votes = {};
+        for (var x = 0; x < option.length; x++) { votes[x.toString()] = 0; }
+
+        msg.guild.settings.update([
+            ["poll.info", `${title.trim()}|${desc.trim()}`],
+            ["poll.options", option],
+            ["poll.votes", JSON.stringify(votes)]
+        ]);
+
+        msg.sendLocale("POLL_CREATED", [msg]);
+    }
+};

--- a/commands/Fun/Polling/endPoll.js
+++ b/commands/Fun/Polling/endPoll.js
@@ -1,0 +1,32 @@
+const { Command } = require("klasa");
+
+module.exports = class extends Command {
+    constructor(...args) {
+        super(...args, {
+            name: "endpoll",
+            runIn: ["text"],
+            description: "Close and finalize the guild's active poll.",
+            extendedHelp: "Ending the poll will bring up the display one more time and then clear the poll."
+        });
+    }
+
+    async run(msg) {
+        var pollData = msg.guild.settings.poll;
+
+        //No poll happening
+        if (!pollData.info) { return msg.sendLocale("POLL_NOPOLL", [msg]); }
+            
+        var title = pollData.info.split("|")[0],
+            desc = pollData.info.split("|")[1],
+            votes = JSON.parse(pollData.votes),
+            optionDisplay = ""
+            header = `The poll has ended!\n__${title}__\n${desc}\n\n`;
+
+        for (var x = 0; x < pollData.options.length; x++) {
+            optionDisplay = optionDisplay.concat(`${x + 1}) ${pollData.options[x]}: ${votes[x]}\n`);
+        }
+
+        msg.channel.send(optionDisplay);
+        msg.guild.settings.reset(["poll.info", "poll.options", "poll.votes", "poll.userVotes"]);
+    }
+};

--- a/commands/Fun/Polling/poll.js
+++ b/commands/Fun/Polling/poll.js
@@ -27,7 +27,7 @@ module.exports = class extends Command {
             extendedHelp: "Note: end will bring up the display one more time and then clear the poll."
         });
 
-        this.humanUse = "<new|vote|end|show>_[title (if new) or option number (if vote)]_[description (new only)]_[...options (new only)]"
+        this.humanUse = "";
     }
 
     async new(msg, [title, desc, ...option]) {

--- a/commands/Fun/Polling/vote.js
+++ b/commands/Fun/Polling/vote.js
@@ -1,0 +1,40 @@
+const { Command, Possible } = require("klasa");
+
+module.exports = class extends Command {
+    constructor(...args) {
+        super(...args, {
+            name: "vote",
+            runIn: ["text"],
+            description: "Vote in the active poll!",
+            usage: "[option:str]"
+        });
+
+        this.humanUse = "[option number]";
+    }
+
+    async run(msg, [option]) {
+        //Can't use integerCheck in the usage alongside title. Run the argument within the vote method instead.
+        //Method will stop automatically if integerCheck detects a bad number.
+        option = await this.client.arguments.get("integerCheck").run(option, new Possible([, "option", "integercheck", 1, undefined, undefined]), msg);
+        option--; //Reduce option by one to work with array index of 0.
+
+        var pollData = msg.guild.settings.poll,
+            userResults = JSON.parse(pollData.userVotes),
+            voteTotal = JSON.parse(pollData.votes);
+
+        if (Object.keys(userResults).includes(msg.author.id)) {
+            var previousVote = userResults[msg.author.id];
+            voteTotal[previousVote]--;
+        }
+
+        userResults[msg.author.id] = option;
+        voteTotal[option]++;
+
+        msg.guild.settings.update([
+            ["poll.votes", JSON.stringify(voteTotal)],
+            ["poll.userVotes", JSON.stringify(userResults)]
+        ]);
+
+        msg.sendLocale("POLL_VOTED", [msg, pollData.options[option]]);
+    }
+};

--- a/commands/Music/join.js
+++ b/commands/Music/join.js
@@ -15,8 +15,8 @@ module.exports = class extends Command {
     
         var vcID = msg.guild.channels.cache.get(msg.member.voice.channelID);
         const permissions = vcID.permissionsFor(msg.guild.me);
-        if (permissions.has("CONNECT") === false) { return msg.channel.send(this.client.speech(msg, ["join", "noConnect"])); }
-        if (permissions.has("SPEAK") === false) { return msg.channel.send(this.client.speech(msg, ["join", "noSpeak"])); }
+        if (permissions.has("CONNECT") === false) { return msg.sendLocale("JOIN_NOCONNECT", [msg]); }
+        if (permissions.has("SPEAK") === false) { return msg.sendLocale("JOIN_NOSPEAK", [msg]); }
 
         var vcSettings = {
             channel: vcID,
@@ -30,6 +30,6 @@ module.exports = class extends Command {
         vcID.join().then(connection => { vcSettings.connection = connection; });
         this.client.music.set(msg.guild.id, vcSettings);
 
-        msg.channel.send(this.client.speech(msg, ["join", "success"], [["-param1", vcID.name]]));    
+        msg.sendLocale("JOIN_SUCCESS", [msg, vcID.name]);  
     }
 };

--- a/commands/Music/leave.js
+++ b/commands/Music/leave.js
@@ -15,6 +15,6 @@ module.exports = class extends Command {
 
         vcID.channel.leave();
         this.client.music.delete(msg.guild.id);
-        msg.channel.send(this.client.speech(msg, ["leave"], [["-channel", vcID.channel.name]]));  
+        msg.sendLocale("LEAVE", [msg, vcID.channel.name]);
     }
 };

--- a/commands/Music/nowplaying.js
+++ b/commands/Music/nowplaying.js
@@ -16,9 +16,9 @@ module.exports = class extends Command {
 
     async run(msg) {
         const handler = this.client.music.get(msg.guild.id, "handler");
-        if (!handler) { throw this.client.speech(msg, ["func-music", "general", "noQueue"]); }
-        if (handler.queue.length < 1) { return this.client.speech(msg, ["nowplaying", "noQueue"]); }
-        if (handler.state !== "PLAY") { return this.client.speech(msg, ["nowplaying", "notPlay"]); }
+        if (!handler) { throw msg.language.get("MUSICCHECK_NOQUEUE"); } 
+        if (handler.queue.length < 1) { return msg.sendLocale("NOWPLAYING_NOQUEUE", [msg]); }
+        if (handler.state !== "PLAY") { return msg.sendLocale("NOWPLAYING_PAUSED", [msg]); }
   
         let song = handler.queue[0];
         const embed = new MessageEmbed()

--- a/commands/Music/pause.js
+++ b/commands/Music/pause.js
@@ -12,10 +12,10 @@ module.exports = class extends Command {
     async run(msg) {
         var handler = this.client.util.musicCheck(msg, "handler");
         if (handler === false) { return; }
-        if (handler.state === "PAUSE") { return msg.channel.send(this.client.speech(msg, ["pause", "paused"])); }
+        if (handler.state === "PAUSE") { return msg.sendLocale("PAUSE_ALREADY", [msg]); }
 
         handler.dispatcher.pause(); //Breaks when the bot hasn't started to play yet. Potentially a musicCheck requirement.
         handler.state = "PAUSE"; //Execute after since bot will not be able to resume if pause() errors
-        msg.channel.send(this.client.speech(msg, ["pause", "success"]));
+        msg.sendLocale("PAUSE_SUCCESS", [msg]);
     }
 };

--- a/commands/Music/play.js
+++ b/commands/Music/play.js
@@ -21,16 +21,16 @@ module.exports = class extends Command {
                 return this.run(msg);
             }
 
-            throw msg.channel.send(this.client.speech(msg, ["func-music", "general", "userVC"]));
+            throw msg.sendLocale("MUSICCHECK_USERNOVC");
         }
 
         if (handler.state === "PLAY") { 
-            if (msg.member.voice.channelID !== handler.channel.id) { throw msg.channel.send(this.client.speech(msg, ["func-music", "general", "mismatch"])); }
+            if (msg.member.voice.channelID !== handler.channel.id) { throw msg.sendLocale("MUSICCHECK_MISMATCHVC"); }
 
-            throw msg.channel.send(this.client.speech(msg, ["play", "alreadyPlay"]));
+            throw msg.sendLocale("PLAY_ALREADY", [msg]);
         } else if (handler.state === "PAUSE") { return this.client.commands.get("resume").run(msg); }
 
-        if (handler.queue.length === 0) { return msg.channel.send(this.client.speech(msg, ["play", "noQueue"])); }
+        if (handler.queue.length === 0) { return msg.sendLocale("PLAY_NOQUEUE", [msg]); }
     
         handler.state = "PLAY";
         this.play(msg, handler, handler.queue[0]);
@@ -40,12 +40,12 @@ module.exports = class extends Command {
 
     play(msg, handler, song) {
         if (song === undefined) {
-            return msg.channel.send(this.client.speech(msg, ["play", "allDone"])).then(() => {
+            return msg.sendLocale("PLAY_FINISHED", [msg]).then(() => {
                 handler.state = "STOP";
             });
         }
 
-        msg.channel.send(this.client.speech(msg, ["play", "nextSong"], [["-param1", song.requester], ["-param2", song.title]]));
+        msg.sendLocale("PLAY_NEXTSONG", [msg, song.requester, song.title]);
   
         return handler.dispatcher = handler.connection.play(yt(song.url, { audioonly: true }), { passes: 2 })
             .on("end", () => { setTimeout(() => {

--- a/commands/Music/queue.js
+++ b/commands/Music/queue.js
@@ -16,13 +16,13 @@ module.exports = class extends Command {
 
     async run(msg, [page=1]) {
         const handler = this.client.music.get(msg.guild.id);
-        if (!handler) { throw this.client.speech(msg, ["func-music", "general", "noQueue"]); }
-        if (handler.queue.length < 1) { throw this.client.speech(msg, ["queue", "noList"]); }
+        if (!handler) { throw msg.sendLocale("MUSICCHECK_NOQUEUE"); } 
+        if (handler.queue.length < 1) { throw msg.sendLocale("QUEUE_NOQUEUE", [msg]); }
       
         if (page.length < 1 || page === 1) { page = 1; var count = 0; }
         else { var count = (10 * (page - 1)); } 
       
-        if (handler.queue.length < count) { return this.client.speech(msg, ["queue", "highCount"], [Math.ceil(handler.queue.length / 10)]); }
+        if (handler.queue.length < count) { return msg.sendLocale("QUEUE_HIGHCOUNT", [msg, Math.ceil(handler.queue.length / 10)]); }
       
         const embed = new MessageEmbed()
             .setColor(0x04d5fd)

--- a/commands/Music/queueadd.js
+++ b/commands/Music/queueadd.js
@@ -21,7 +21,7 @@ module.exports = class extends Command {
         var id = [];
       
         if (song.match(/(playlist\?list=\S{30,34})/)) { 
-            msg.channel.send(this.client.speech(msg, ["queueadd", "listDetect"]));
+            msg.sendLocale("QUEUEADD_LISTDETECT", [msg]);
             var list = await Promise.resolve(ytPlay(song, "id"));
               
             for(var x = 0; x < list.data.playlist.length; x++) {
@@ -29,8 +29,8 @@ module.exports = class extends Command {
             }
         } else if (song.match(/(?:v=)(\S{11})/)) {
             id.push(song.match(/(?:v=)(\S{11})/)[1]);
-        } else { throw msg.channel.send(this.client.speech(msg, ["queueadd", "noURL"])); }
-      
+        } else { throw msg.sendLocale("QUEUEADD_NOURL", [msg]); } 
+       
         for (var x = 0; x < id.length; x++) {
             try {
                 var info = await getInfoAsync(`https://youtu.be/${id[x]}`);
@@ -41,10 +41,10 @@ module.exports = class extends Command {
                     seconds: info.length_seconds,
                     requester: msg.author.tag
                 });
-            } catch(err) { msg.channel.send(this.client.speech(msg, ["queueadd", "errCatch"], [["-param1", id[x]]])); }    
+            } catch(err) { msg.sendLocale("QUEUEADD_ERRCATCH", [msg, id[x]]); }
         }
       
-        if (id.length === 1) { msg.channel.send(this.client.speech(msg, ["queueadd", "success"], [["-param1", info.title]])); }
-        else { msg.channel.send(this.client.speech(msg, ["queueadd", "multi"], [["-param1", id.length]])); }
+        if (id.length === 1) { msg.sendLocale("QUEUEADD_SUCCESS", [msg, info.title]); }
+        else { msg.sendLocale("QUEUEADD_MULTI", [msg, id.length]); }
     }
 };

--- a/commands/Music/remove.js
+++ b/commands/Music/remove.js
@@ -17,6 +17,6 @@ module.exports = class extends Command {
         
         var title = handler.queue[songID].title;
         handler.queue.splice(songID, 1);
-        msg.channel.send(this.client.speech(msg, ["remove"], [["-song", title]]));  
+        msg.sendLocale("REMOVEMUSIC", [msg, title]);
     }
 };

--- a/commands/Music/resume.js
+++ b/commands/Music/resume.js
@@ -12,10 +12,10 @@ module.exports = class extends Command {
     async run(msg) {
         var handler = this.client.util.musicCheck(msg, "handler");
         if (handler === false) { return; }
-        if (handler.state !== "PAUSE") { return msg.channel.send(this.client.speech(msg, ["resume", "noPause"])); }
+        if (handler.state !== "PAUSE") { return msg.sendLocale("RESUME_NOPAUSE", [msg]); }
 
         handler.dispatcher.resume();
         handler.state = "PLAY";
-        msg.channel.send(this.client.speech(msg, ["resume", "success"]));
+        msg.sendLocale("RESUME_SUCCESS", [msg]);
     }
 };

--- a/commands/Music/skip.js
+++ b/commands/Music/skip.js
@@ -14,6 +14,6 @@ module.exports = class extends Command {
         if (handler === false) { return; }
 
         handler.dispatcher.end();
-        msg.channel.send(this.client.speech(msg, ["skip"])); 
+        msg.sendLocale("SKIPMUSIC", [msg]);
     }
 };

--- a/commands/Music/volume.js
+++ b/commands/Music/volume.js
@@ -15,15 +15,15 @@ module.exports = class extends Command {
         var handler = this.client.util.musicCheck(msg, "handler");
         if (handler === false) { return; }
 
-        if (!volume) { return msg.channel.send(this.client.speech(msg, ["volume", "noArgs"], [["-vol",Math.round(dispatcher.volume * 50)]])); }
-        if (volume === 0) { return msg.channel.send(this.client.speech(msg, ["volume", "zero"])); }
-        if (volume > 100) { return msg.channel.send(this.client.speech(msg, ["volume", "overHun"])); }
-        if (handler.playing !== "PLAY") { return msg.channel.send(this.client.speech(msg, ["volume", "notPlay"])); }       
+        if (!volume) { return msg.sendLocale("VOLUME_NOARGS", [msg, Math.round(dispatcher.volume * 50)]); }
+        if (volume === 0) { return msg.sendLocale("VOLUME_ZERO", [msg]); } 
+        if (volume > 100) { return msg.sendLocale("VOLUME_MAX", [msg]); } 
+        if (handler.playing !== "PLAY") { return msg.sendLocale("VOLUME_PAUSED", [msg]); }      
       
         const dispatcher = handler.dispatcher;
         var emote = (volume < (dispatcher.volume * 50)) ? ["🔉 Decreasing"] : ["🔊 Increasing"];
       
         dispatcher.setVolume(Math.min(volume) / 50, 2);
-        msg.channel.send(this.client.speech(msg, ["volume", "success"], [["-param1", emote], ["-param2", Math.round(dispatcher.volume * 50)]]));
+        msg.sendLocale("VOLUME_SUCCESS", [msg, emote, Math.round(dispatcher.volume * 50)]);
     }
 };

--- a/commands/System/report.js
+++ b/commands/System/report.js
@@ -6,6 +6,7 @@ module.exports = class extends Command {
         super(...args, {
             name: "report",
             enabled: true,
+            guarded: true,
             runIn: ["text"],
             requiredPermissions: ["EMBED_LINKS"],
             description: "File a report to the bot owner. (ie: Bug, issue, complaint)",

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,5 +1,6 @@
-const { Event } = require("klasa");
+const { Event, KlasaUser } = require("klasa");
 const { Collection } = require("discord.js");
+const { secondary } = require("../assets/settings.json");
 
 module.exports = class extends Event {
 	constructor(...args) {
@@ -12,5 +13,21 @@ module.exports = class extends Event {
 	async run() {
 		this.client.util.presenceHelper(this.client, "-start"); //Initialize presence
 		this.client.settings.usedDaily = new Collection(); //A collection to store a tuple with a userID and a timestamp.
+
+		//Figure out and apply level 10 permission to application owner and level 9 permission to any listed
+		//Secondary accounts or team members (if owner is team based)
+		var botApp = this.client.application.owner;
+
+		if (botApp instanceof KlasaUser) { 
+			this.client.owner = botApp; 
+			this.client.secondary = secondary;
+		} else { 
+			this.client.owner = botApp.owner.user;
+			this.client.secondary = [];
+
+			botApp.members.each(user => {
+				this.client.secondary.push(user.id);
+			});
+		}
 	}
 };

--- a/index.js
+++ b/index.js
@@ -37,6 +37,6 @@ client.globalPrefix = config.prefix;
 
 client.itemData = require("./assets/items.json");
 
-commandRemover(client);
+commandRemover();
 
 client.login(config.token);

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ Client.defaultPermissionLevels
     .add(5, ({ guild, member }) => guild && member.roles.cache.has(guild.settings.modRole))
     .add(6, ({ guild, member }) => guild && member.permissions.has("ADMINISTRATOR"))
     .add(7, ({ guild, member }) => guild && guild.ownerID === member.id)
-    .add(9, ({ author, client }) => author === client.owner || author.id === config.secondary)
+    .add(9, ({ author, client }) => author === client.owner || author.id === config.secondary || config.secondary.contains(author.id))
     .add(10, ({ author, client }) => author === client.owner);
 
 schemaManager(client); //Adds all configurable settings.

--- a/inhibitors/properPermission.js
+++ b/inhibitors/properPermission.js
@@ -1,0 +1,31 @@
+const { Inhibitor } = require("klasa");
+
+module.exports = class extends Inhibitor {
+    constructor(...args) {
+        super(...args, {
+            name: "properPermission",
+            enabled: true
+        });
+    }
+
+    //Checks if higher permission level users can use this command.
+    //IE: Bot primary and secondary owners.
+    async run(msg, cmd) {
+        //Inhibitor is not meant for DM use or commands lower than 5 (Moderator level).
+        if (!msg.guild || cmd.permissionLevel < 5) { return; }
+        
+        //Guild leaders have access to all mid-range permission level commands.
+        if (msg.guild.owner.id === msg.author.id) { return; }
+
+        var user = msg.guild.members.cache.get(msg.author.id);
+
+        if (cmd.permissionLevel === 6 && user.permissions.has("ADMINISTRATOR")) { return; }
+
+        if (cmd.permissionLevel === 5) {
+            if (user.permissions.has("ADMINISTRATOR") || user.roles.cache.has(msg.guild.settings.modRole)) { return; }
+            throw true;
+        }
+
+        throw true;
+    }
+};

--- a/languages/en-CA.js
+++ b/languages/en-CA.js
@@ -263,6 +263,8 @@ module.exports = class extends Language {
 			 */
 			FISH: (msg, emote) => this.client.speech(msg, ["fish"], [["-kind", emote]]),
 			HARVEST: (msg, emote) => this.client.speech(msg, ["harvest"], [["-kind", emote]]),
+			CRAFT: (msg, amount, emote) => this.client.speech(msg, ["craft", "success"], [["-amount", amount], ["-item", emote]]),
+			SELL: (msg, emote, amount, price)=> this.client.speech(msg, ["sell", "success"], [["-item", emote], ["-amount", amount], ["-price", price]]), 
 
 			/*
 			 * Commands - Owner

--- a/languages/en-CA.js
+++ b/languages/en-CA.js
@@ -172,6 +172,9 @@ module.exports = class extends Language {
 			DATACHECK_LACKCREDIT: this.client.speech(falseMsg, ["func-dataCheck", "lackCredits"]),
 			DATACHECK_SAMEUSER: this.client.speech(falseMsg, ["func-dataCheck", "sameUser"]),
 			DATACHECK_COOLDOWN: this.client.speech(falseMsg, ["func-dataCheck", "cooldown"]),
+			DATACHECK_NOITEMS: this.client.speech(falseMsg, ["func-dataCheck", "noItems"]),
+			DATACHECK_NORECIPE: this.client.speech(falseMsg, ["func-dataCheck", "noRecipe"]),
+			DATACHECK_NOZERO: this.client.speech(falseMsg, ["func-dataCheck", "noZero"]),
 			MUSICCHECK_USERNOVC: this.client.speech(falseMsg, ["func-music", "general", "userVC"]),
 			MUSICCHECK_NOQUEUE: this.client.speech(falseMsg, ["func-music", "general", "noQueue"]),
 			MUSICCHECK_MISMATCHVC: this.client.speech(falseMsg, ["func-music", "general", "mismatch"]),
@@ -254,6 +257,12 @@ module.exports = class extends Language {
 			COIN_LOSS: (msg, result, bet) => this.client.speech(msg, ["coin", "lose"], [["-result", result], ["-earning", bet]]),
 			CHOUHAN_SUCCESS: (msg, sum, guess, bet) => this.client.speech(msg, ["chouhan", "win"], [["-sum", sum], ["-guess", guess], ["-earning", (bet * 2)]]),
 			CHOUHAN_LOSS: (msg, sum, guess, bet) => this.client.speech(msg, ["chouhan", "lose"], [["-sum", sum], ["-guess", guess], ["-earning", bet]]),
+
+			/*
+			 * Commands - Economy => Cooking
+			 */
+			FISH: (msg, emote) => this.client.speech(msg, ["fish"], [["-kind", emote]]),
+			HARVEST: (msg, emote) => this.client.speech(msg, ["harvest"], [["-kind", emote]]),
 
 			/*
 			 * Commands - Owner

--- a/languages/en-CA.js
+++ b/languages/en-CA.js
@@ -281,6 +281,24 @@ module.exports = class extends Language {
 			INVITE: (invite) => `My invite link: <${invite}> \nThe above invite link is generated requesting the minimum permissions required to run all of my current commands. If there is a command that requires another permission that is not selected, I will let you know so that you can make those changes. :smile:`,
 			PERMLEVEL_OWNER: (permLvl, info) => `Your permission level is ${permLvl} ${info}`,
 			PERMLEVEL_USER: (permLvl) => `Your permission level is ${permLvl}`,
+
+			/*
+			 * Commands - Music
+			 */
+			JOIN_NOCONNECT: (msg) => this.client.speech(msg, ["join", "noConnect"]),
+			JOIN_NOSPEAK: (msg) => this.client.speech(msg, ["join", "noSpeak"]),
+			JOIN_SUCCESS: (msg, channelName) => this.client.speech(msg, ["join", "success"], [["-param1", channelName]]),
+			LEAVE: (msg, channelName) => this.client.speech(msg, ["leave"], [["-channel", channelName]]),
+			NOWPLAYING_NOQUEUE: (msg) => this.client.speech(msg, ["nowplaying", "noQueue"]),
+			NOWPLAYING_PAUSED: (msg) => this.client.speech(msg, ["nowplaying", "notPlay"]),
+			PAUSE_ALREADY: (msg) => this.client.speech(msg, ["pause", "paused"]),
+			PAUSE_SUCCESS: (msg) => this.client.speech(msg, ["pause", "success"]),
+			PLAY_ALREADY: (msg) => this.client.speech(msg, ["play", "alreadyPlay"]),
+			PLAY_NOQUEUE: (msg) => this.client.speech(msg, ["play", "noQueue"]),
+			PLAY_FINISHED: (msg) => this.client.speech(msg, ["play", "allDone"]),
+			PLAY_NEXTSONG: (msg, requester, title) => this.client.speech(msg, ["play", "nextSong"], [["-param1", requester], ["-param2", title]]),
+			QUEUE_NOQUEUE: (msg) => this.client.speech(msg, ["queue", "noList"]),
+			QUEUE_HIGHCOUNT: (msg, pageCount) => this.client.speech(msg, ["queue", "highCount"], [["-pgs", pageCount]]),
 		};
     }
 };

--- a/languages/en-CA.js
+++ b/languages/en-CA.js
@@ -192,6 +192,10 @@ module.exports = class extends Language {
 			STARBOARD_WRONGITEM: (msg) => this.client.speech(msg, ["starboard", "wrongItem"]),
 			STARBOARD_SETITEM: (msg, target, item) => this.client.speech(msg, ["starboard", "set"], [["-target", target], ["-item", item]]), 
 			SETPREFIX: (msg, prefix) => this.client.speech(msg, ["setprefix"], [["-editPrefix", prefix]]),
+			DCOMMAND_NOSTR: (msg) => this.client.speech(msg, ["disablecommand", "noStr"]),
+            DCOMMAND_DISABLE: (msg, name) => this.client.speech(msg, ["disablecommand", "disable"], [["-name", name]]),
+			DCOMMAND_ENABLE: (msg, name) => this.client.speech(msg, ["disablecommand", "enable"], [["-name", name]]),
+			DCOMMAND_GUARDED: (msg) => this.client.speech(msg, ["disablecommand", "guarded"]),
 
 			/*
 			 * Commands - General
@@ -299,6 +303,20 @@ module.exports = class extends Language {
 			PLAY_NEXTSONG: (msg, requester, title) => this.client.speech(msg, ["play", "nextSong"], [["-param1", requester], ["-param2", title]]),
 			QUEUE_NOQUEUE: (msg) => this.client.speech(msg, ["queue", "noList"]),
 			QUEUE_HIGHCOUNT: (msg, pageCount) => this.client.speech(msg, ["queue", "highCount"], [["-pgs", pageCount]]),
+			QUEUEADD_LISTDETECT: (msg) => this.client.speech(msg, ["queueadd", "listDetect"]),
+			QUEUEADD_NOURL: (msg) => this.client.speech(msg, ["queueadd", "noURL"]),
+			QUEUEADD_ERRCATCH: (msg, songID) => this.client.speech(msg, ["queueadd", "errCatch"], [["-param1", songID]]),
+			QUEUEADD_SUCCESS: (msg, title) => this.client.speech(msg, ["queueadd", "success"], [["-param1", title]]),
+			QUEUEADD_MULTI: (msg, amount) => this.client.speech(msg, ["queueadd", "multi"], [["-param1", amount]]),
+			REMOVEMUSIC: (msg, title) => this.client.speech(msg, ["remove"], [["-song", title]]),
+			RESUME_NOPAUSE: (msg) => this.client.speech(msg, ["resume", "noPause"]),
+			RESUME_SUCCESS: (msg) => this.client.speech(msg, ["resume", "success"]),
+			SKIPMUSIC: (msg) => this.client.speech(msg, ["skip"]),
+			VOLUME_NOARGS: (msg, vol) => this.client.speech(msg, ["volume", "noArgs"], [["-vol", vol]]),
+			VOLUME_ZERO: (msg) => this.client.speech(msg, ["volume", "zero"]),
+			VOLUME_MAX: (msg) => this.client.speech(msg, ["volume", "overHun"]),
+			VOLUME_PAUSED: (msg) => this.client.speech(msg, ["volume", "notPlay"]),
+			VOLUME_SUCCESS: (msg, change, vol) => this.client.speech(msg, ["volume", "success"], [["-param1", change], ["-param2", vol]]),
 		};
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "margarine",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -759,8 +759,9 @@
       }
     },
     "klasa": {
-      "version": "github:dirigeants/klasa#7fbd351c1276a171fdc854bc99f05b5ef89eb32b",
-      "from": "github:dirigeants/klasa",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/klasa/-/klasa-0.5.0.tgz",
+      "integrity": "sha512-BrXP/rCvL7Sh4T3hnSOJTDbT5JT3Q3Di4sAg537OCzH/eRnYbeny4J99vkTGE5Lkm241HNH+kd+DURWaavBa6A==",
       "requires": {
         "fs-nextra": "^0.4.7"
       }
@@ -776,9 +777,9 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "m3u8stream": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.6.5.tgz",
-      "integrity": "sha512-QZCzhcfUliZfsOboi68QkNcMejPKTEhxE+s1TApvHubDeR8ythm4ViWuYFqgUwZeoHe8q0nsPxOvA3lQvdSzyg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.7.1.tgz",
+      "integrity": "sha512-z6ldnAdhbuWOL6LmMkwptSZGzj+qbRytMKLTbNicwF/bJMjf9U9lqD57RNQUFecvWadEkzy6PDjcNJFFgi19uQ==",
       "requires": {
         "miniget": "^1.6.1",
         "sax": "^1.2.4"
@@ -803,9 +804,9 @@
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
     "miniget": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-1.7.0.tgz",
-      "integrity": "sha512-yrgaDSMRzrfYTkudB4Y6xK8pCb7oAH2bvfv6iPY2m6CedZfs9yK4b/ofh0Vzv08hCYXH/HHkoS8an6fkWtOAQA=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-1.7.2.tgz",
+      "integrity": "sha512-USPNNK2bnHLOplX8BZVMehUkyQizS/DFpBdoH0TS+fM+hQoLNg9tWg4MeY9wE8gfY0pbzmx5UBEODujt3Lz8AA=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -851,9 +852,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "moment": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "moment-duration-format": {
       "version": "2.3.2",
@@ -1460,13 +1461,13 @@
       }
     },
     "ytdl-core": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-2.1.2.tgz",
-      "integrity": "sha512-/tOT9Pka6nX+LuvzNLBU8AbVHe8XELn3aZ69mvCxzvwO/ty9k8cRvF6jXqti7l5M+0hf+UPpP9jYPSAFAuoBUA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-2.1.7.tgz",
+      "integrity": "sha512-ithllxxlt4zmJVTnYtT8/31QLv5MGlK3fSk29lx2S4eKc1BGh+ELKQEAkRJqWIf2P8TYBYrKwijx11xND4JcXw==",
       "requires": {
         "html-entities": "^1.3.1",
-        "m3u8stream": "^0.6.3",
-        "miniget": "^1.7.0",
+        "m3u8stream": "^0.7.1",
+        "miniget": "^1.7.2",
         "sax": "^1.1.3"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "margarine",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Javascript bot using the Klasa framework",
   "main": "index.js",
   "dependencies": {
@@ -10,8 +10,8 @@
     "cheerio": "^1.0.0-rc.3",
     "discord.js": "^12.2.0",
     "ffmpeg": "0.0.4",
-    "klasa": "github:dirigeants/klasa",
-    "moment": "^2.25.3",
+    "klasa": "^0.5.0",
+    "moment": "^2.26.0",
     "moment-duration-format": "^2.3.2",
     "ms": "^2.1.2",
     "node-fetch": "^2.6.0",
@@ -19,7 +19,7 @@
     "request": "^2.88.2",
     "snekfetch": "^4.0.4",
     "youtube-playlist": "^1.0.3",
-    "ytdl-core": "^2.1.2"
+    "ytdl-core": "^2.1.7"
   },
   "devDependencies": {},
   "repository": {

--- a/utilities/speechHelper.js
+++ b/utilities/speechHelper.js
@@ -2,6 +2,16 @@ const { existsSync } = require("fs");
 const baseSpeechDir = `${process.cwd()}/assets/speech/`;
 
 /**
+ * Reload a speech module to have the most current changes.
+ * @param {String} PATH - Target file location to reload.
+ * @returns New cached require of the target location
+ */
+function recacheSpeech(PATH) {
+    delete require.cache[require.resolve(PATH)];
+    return require(PATH);
+}
+
+/**
  * Picks a random line to simulate speech.
  * @param {KlasaMessage} msg - The message that was sent.
  * @param {Object[]} keys - Value 0 is the command or function name for searching and Value 1 is the context.
@@ -27,7 +37,9 @@ module.exports = function speech(msg, keys, replace=[]) {
         console.error(`Localization file is missing. Defaulted to the original language.\nLanguage: ${msg.guild.settings.language}\nCategory: ${category}\nCommand: ${name}\n${PATH}\n\n`);
     }
 
-    var t = require(PATH); var n;
+    var t = recacheSpeech(PATH);
+    var n;
+
     if (!name.startsWith("func-")) { t = t[name]; n = 1; }
     else { t = t[keys[1]]; n = 2; }
     for (var x = n; x < keys.length; x++) { t = t[keys[x]]; }

--- a/utilities/utilExport.js
+++ b/utilities/utilExport.js
@@ -31,7 +31,7 @@ exports.envCheck = function() {
     nVersion = Number(`${nVersion[0]}.${nVersion[1]}`);
 
     if (djsVersion !== "12.2.0") { missingDep.push("You are not using the right discord.js package! Required version: v12.2.0"); }
-    if (kVersion !== "0.5.0-dev") { missingDep.push("You are not using the right Klasa version! Required version: v0.5.0-dev"); }
+    if (kVersion !== "0.5.0") { missingDep.push("You are not using the right Klasa version! Required version: v0.5.0"); }
     if (nVersion < 12.0) { missingDep.push("You are not using the right node.js version! Required version: v12.0.0+"); }
 
     if (missingDep.length > 0) { console.log(missingDep.join("\n")); process.exit(); }

--- a/utilities/utilExport.js
+++ b/utilities/utilExport.js
@@ -1,4 +1,4 @@
-const { existsSync, unlinkSync } = require("fs");
+const { existsSync, unlinkSync, rmdirSync } = require("fs");
 const { version: djsVersion } = require("discord.js");
 const { version: kVersion } = require("klasa");
 /* Exports all needed utilities for the client. */
@@ -8,13 +8,15 @@ exports.dataManager = require("./dataManager.js");
 exports.schemaManager = require("./schemaManager.js");
 
 /** Removes any unnessesscary commands in the default Klasa framework.
- * @param { KlasaClient } client
  */
-exports.commandRemover = function(client) {
-    const cmdNames = ["Admin/load", "Admin/unload", "Admins/transfer", "General/Chat Bot Info/info", "General/Chat Bot Info/stats", "General/User Settings/userconf"];
+exports.commandRemover = function() {
+    const cmdNames = ["Admin/load", "Admin/unload", "Admins/transfer"];
+    if (existsSync(`${process.cwd()}/node_modules/klasa/src/commands/General`)) {
+        rmdirSync(`${process.cwd()}/node_modules/klasa/src/commands/General`, { recursive: true });
+    }
     for(var x = 0; x < cmdNames.length; x++) {
-        if (existsSync(`${client.userBaseDirectory}/node_modules/klasa/src/commands/${cmdNames[x]}.js`)) {
-            unlinkSync(`${client.userBaseDirectory}/node_modules/klasa/src/commands/${cmdNames[x]}.js`);
+        if (existsSync(`${process.cwd()}/node_modules/klasa/src/commands/${cmdNames[x]}.js`)) {
+            unlinkSync(`${process.cwd()}/node_modules/klasa/src/commands/${cmdNames[x]}.js`);
         }
     }
 };

--- a/utilities/utilExport.js
+++ b/utilities/utilExport.js
@@ -10,7 +10,7 @@ exports.schemaManager = require("./schemaManager.js");
 /** Removes any unnessesscary commands in the default Klasa framework.
  */
 exports.commandRemover = function() {
-    const cmdNames = ["Admin/load", "Admin/unload", "Admins/transfer"];
+    const cmdNames = ["Admin/load", "Admin/unload", "Admin/transfer", "Admin/reboot"];
     if (existsSync(`${process.cwd()}/node_modules/klasa/src/commands/General`)) {
         rmdirSync(`${process.cwd()}/node_modules/klasa/src/commands/General`, { recursive: true });
     }


### PR DESCRIPTION
**Added**
- Speech modules will now reload to their most recent changes when processing responses.
- New configurable command: disableCommand. Disable/re-enable a command for your guild. Available to Admins+
- New inhibitor: properPermission. See the third major fix in list for details.
- Margarine will now identify team members if the application is team-owned. Team leader will get level 10 and all other members will get level 9.

**Modifications**
- Klasa package is now taken from NPM instead of Github.
- noRecipe speech calls are made from dataCheck module instead of cooking module. Speech is still preserved for backward compatibility with v1.3.0.
- Harvest speech is now an array type. Removed old speech lines that were replaced by dataCheck module.
- commandRemover no longer requires the client
- Split up the poll command into user-friendly commands. Added a new subcategory, Polling, to contain them. All features are usable through the Poll command for backward compatibility.

**Fixes**
- [Major] Harvest success messages will now be displayed as harvest speech was affected by old speech lines.
- [Major] Patched an issue with finding the bot's owner with Klasa v0.5.0 NPM package.
- [Major] Increased security on guild configure and moderator commands when it comes to bot owners. Commands will fail silently now upon failing the check.
- [Minor] Trying to end a poll will no longer error if there is no poll ongoing.
- [Minor] Fixed an issue with the Queue command's response when the given page count is higher than the queue's.

**Removed**
- Klasa's built-in transfer and reboot commands are removed via commandRemover.